### PR TITLE
GPT4 support and formatting changed text only

### DIFF
--- a/AI Studio.csproj
+++ b/AI Studio.csproj
@@ -52,6 +52,7 @@
     <Compile Include="Commands\Refactor.cs" />
     <Compile Include="Commands\CodeIt.cs" />
     <Compile Include="Commands\SecurityCheck.cs" />
+    <Compile Include="Enums\ChatLanguageModel.cs" />
     <Compile Include="Enums\FluentAssertionFramework.cs" />
     <Compile Include="Enums\IsolationFramework.cs" />
     <Compile Include="Enums\ResponseBehavior.cs" />

--- a/Commands/AIBaseCommand.cs
+++ b/Commands/AIBaseCommand.cs
@@ -1,8 +1,12 @@
 ﻿using EnvDTE;
 using Microsoft.VisualStudio.Shell.Interop;
+using Microsoft.VisualStudio.Text;
 using OpenAI_API;
+using OpenAI_API.Chat;
+using OpenAI_API.Models;
 using System.Collections.Generic;
 using System.Linq;
+using System.Text.RegularExpressions;
 
 namespace AI_Studio
 {
@@ -12,6 +16,9 @@ namespace AI_Studio
         public string UserInput { get; set; }
         public List<string> AssistantInputs  { get; set; } = new List<string>();
         public ResponseBehavior ResponseBehavior { get; set; }
+
+        protected bool _addContentTypePrefix = false;
+        protected bool _stripResponseMarkdownCode = false;
 
         protected override async Task ExecuteAsync(OleMenuCmdEventArgs e)
         {
@@ -34,7 +41,16 @@ namespace AI_Studio
 
             var docView = await VS.Documents.GetActiveDocumentViewAsync();
             var selection = docView.TextView.Selection.SelectedSpans.FirstOrDefault();
+            if (selection.Length == 0)
+            {
+                var textBuffer = docView.TextView.TextBuffer;
+                var line = textBuffer.CurrentSnapshot.GetLineFromPosition(selection.Start.Position);
+                var snapshotSpan = new SnapshotSpan(line.Start, line.End);
+                docView.TextView.Selection.Select(snapshotSpan, false);
+                selection = docView.TextView.Selection.SelectedSpans.FirstOrDefault();
+            }
             var text = docView.TextView.Selection.StreamSelectionSpan.GetText();
+            int selectionStartLineNumber = docView.TextView.TextBuffer.CurrentSnapshot.GetLineNumberFromPosition(selection.Start.Position);
 
             if (string.IsNullOrEmpty(text))
             {
@@ -42,8 +58,22 @@ namespace AI_Studio
                 await VS.MessageBox.ShowAsync("Nothing Selected!", buttons: OLEMSGBUTTON.OLEMSGBUTTON_OK);
             }
 
+            if (_addContentTypePrefix)
+            {
+                text = $"{docView.TextView.TextDataModel.ContentType.DisplayName}\n{text}";
+            }
+
             var api = new OpenAIAPI(generalOptions.ApiKey);
-            var chat = api.Chat.CreateConversation();
+            var chatRequestTemplate = new ChatRequest()
+            {
+                Model = generalOptions.LanguageModel switch
+                {
+                    ChatLanguageModel.GPT4 => Model.GPT4,
+                    ChatLanguageModel.GPT4_32k_Context => Model.GPT4_32k_Context,
+                    _ => Model.ChatGPTTurbo
+                }
+            };
+            var chat = api.Chat.CreateConversation(chatRequestTemplate);
 
             chat.AppendSystemMessage(SystemMessage);
             chat.AppendUserInput(text);
@@ -59,6 +89,11 @@ namespace AI_Studio
             try
             {
                 string response = await chat.GetResponseFromChatbotAsync();
+                
+                if (_stripResponseMarkdownCode)
+                {
+                    response = StripResponseMarkdownCode(response);
+                }
 
                 twd.EndWaitDialog();
 
@@ -81,10 +116,25 @@ namespace AI_Studio
                 await VS.MessageBox.ShowAsync(ex.Message, buttons: OLEMSGBUTTON.OLEMSGBUTTON_OK);
             }
 
-            if (generalOptions.FormatDocument && ResponseBehavior != ResponseBehavior.Message)
+            if (generalOptions.FormatChangedText && ResponseBehavior != ResponseBehavior.Message)
             {
-                (await VS.GetServiceAsync<DTE, DTE>()).ExecuteCommand("Edit.FormatDocument", string.Empty);
+                selection = docView.TextView.Selection.SelectedSpans.FirstOrDefault();
+                if (selection.Length == 0)
+                {
+                    var startLine = docView.TextView.TextBuffer.CurrentSnapshot.GetLineFromLineNumber(selectionStartLineNumber);
+                    var endLine = docView.TextView.TextBuffer.CurrentSnapshot.GetLineFromPosition(selection.End);
+                    var snapshotSpan = new SnapshotSpan(startLine.Start, endLine.End);
+                    docView.TextView.Selection.Select(snapshotSpan, false);
+                }
+
+                (await VS.GetServiceAsync<DTE, DTE>()).ExecuteCommand("Edit.FormatSelection");
             }
+        }
+
+        private string StripResponseMarkdownCode(string response)
+        {
+            var regex = new Regex(@"```.*\r?\n?");
+            return regex.Replace(response, "");
         }
     }
 }

--- a/Commands/AddComments.cs
+++ b/Commands/AddComments.cs
@@ -1,4 +1,6 @@
-﻿namespace AI_Studio
+﻿using System.Text.RegularExpressions;
+
+namespace AI_Studio
 {
     [Command(PackageIds.AddComments)]
     internal sealed class AddComments : AIBaseCommand<AddComments>
@@ -11,6 +13,7 @@
             var opts = await Commands.GetLiveInstanceAsync();
 
             UserInput = opts.AddComments;
+            _stripResponseMarkdownCode = true;
 
             await base.ExecuteAsync(e);
         }

--- a/Commands/CodeIt.cs
+++ b/Commands/CodeIt.cs
@@ -1,4 +1,6 @@
-﻿namespace AI_Studio
+﻿using System.Text.RegularExpressions;
+
+namespace AI_Studio
 {
     [Command(PackageIds.CodeIt)]
     internal sealed class CodeIt : AIBaseCommand<CodeIt>
@@ -11,6 +13,8 @@
             var opts = await Commands.GetLiveInstanceAsync();
 
             UserInput = opts.CodeIt;
+            _addContentTypePrefix = true;
+            _stripResponseMarkdownCode = true;
 
             await base.ExecuteAsync(e);
         }

--- a/Commands/Refactor.cs
+++ b/Commands/Refactor.cs
@@ -1,4 +1,6 @@
-﻿namespace AI_Studio
+﻿using System.Text.RegularExpressions;
+
+namespace AI_Studio
 {
     [Command(PackageIds.Refactor)]
     internal sealed class Refactor : AIBaseCommand<Refactor>
@@ -11,6 +13,7 @@
             ResponseBehavior = ResponseBehavior.Replace;
 
             UserInput = opts.Refactor;
+            _stripResponseMarkdownCode = true;
 
             await base.ExecuteAsync(e);
         }

--- a/Enums/ChatLanguageModel.cs
+++ b/Enums/ChatLanguageModel.cs
@@ -1,0 +1,9 @@
+﻿namespace AI_Studio
+{
+    public enum ChatLanguageModel
+    {
+        ChatGPTTurbo,
+        GPT4,
+        GPT4_32k_Context,
+    }
+}

--- a/Options/Commands.cs
+++ b/Options/Commands.cs
@@ -36,7 +36,7 @@ namespace AI_Studio
         [Category("Commands")]
         [DisplayName("Code It")]
         [Description("Add some suggestions here for Chat GPT to customize 'Code It' command.")]
-        public string CodeIt { get; set; }
+        public string CodeIt { get; set; } = "No explanation";
 
         [Category("Commands")]
         [DisplayName("Security Check")]

--- a/Options/General.cs
+++ b/Options/General.cs
@@ -19,9 +19,15 @@ namespace AI_Studio
         public string ApiKey { get; set; }
 
         [Category("General")]
-        [DisplayName("Format Document")]
-        [Description("Format current document after change.")]
+        [DisplayName("Format Changed Text")]
+        [Description("Format text after change.")]
         [DefaultValue(true)]
-        public bool FormatDocument { get; set; } = true;
+        public bool FormatChangedText { get; set; } = true;
+
+        [Category("General")]
+        [DisplayName("Language Model")]
+        [Description("Chat language model")]
+        [DefaultValue(ChatLanguageModel.ChatGPTTurbo)]
+        public ChatLanguageModel LanguageModel { get; set; } = ChatLanguageModel.ChatGPTTurbo;
     }
 }


### PR DESCRIPTION
- `gpt-4` and `gpt-4-32k` support added;
- If no text is selected for request then the whole line gets selected automatically
- `Format Document` option changed to `Format Changed Text` - only the part that is changed will be formatted, not the whole document
- `CodeIt` - programming language name (document type actually) is added as a prefix to the request
- A markdown code wrapping tags are removed from the response