### PR TITLE
Updated option page to accept organization owner and language model ID for custom OpenAI Endpoints

### DIFF
--- a/Commands/AIBaseCommand.cs
+++ b/Commands/AIBaseCommand.cs
@@ -33,6 +33,14 @@ namespace AI_Studio
                 return;
             }
 
+            if (generalOptions.LanguageModel == ChatLanguageModel.Custom && String.IsNullOrEmpty(generalOptions.CustomLanguageModel))
+            {
+                await VS.MessageBox.ShowAsync("Please specify a custom language model ID while Language Model is set to \"Custom\"", $"Go to Tools/Options/AI Stuido/General and provide the language model ID provided from your endpoint at: {Environment.NewLine}{Environment.NewLine}{string.Format(generalOptions.ApiEndpoint,"v1", "models")}", buttons: OLEMSGBUTTON.OLEMSGBUTTON_OK);
+
+                Package.ShowOptionPage(typeof(General));
+                return;
+            }
+
             await ThreadHelper.JoinableTaskFactory.SwitchToMainThreadAsync();
             var fac = (IVsThreadedWaitDialogFactory)await VS.Services.GetThreadedWaitDialogAsync();
             IVsThreadedWaitDialog4 twd = fac.CreateInstance();
@@ -77,6 +85,7 @@ namespace AI_Studio
                     ChatLanguageModel.GPT4_32k_Context => Model.GPT4_32k_Context,
                     ChatLanguageModel.GPT4_Turbo => Model.GPT4_Turbo,
                     ChatLanguageModel.GPT4o => new Model("gpt-4o") { OwnedBy = "openai" },
+                    ChatLanguageModel.Custom => new Model(generalOptions.CustomLanguageModel) { OwnedBy = generalOptions.OrganizationOwner },
                     _ => Model.ChatGPTTurbo
                 }
             };

--- a/Enums/ChatLanguageModel.cs
+++ b/Enums/ChatLanguageModel.cs
@@ -7,5 +7,6 @@
         GPT4_32k_Context,
         GPT4_Turbo,
         GPT4o,
+        Custom = 99 // Custom
     }
 }

--- a/Options/General.cs
+++ b/Options/General.cs
@@ -30,10 +30,23 @@ namespace AI_Studio
         [DefaultValue(ChatLanguageModel.ChatGPTTurbo)]
         public ChatLanguageModel LanguageModel { get; set; } = ChatLanguageModel.ChatGPTTurbo;
 
+        [Category("Custom Model")]
+        [DisplayName("Organization")]
+        [Description("Name of the organization or owner of the model.")]
+        [DefaultValue("organization_owner")]
+        public string OrganizationOwner { get; set; } = "";
+
+        [Category("Custom Model")]
+        [DisplayName("Custom Language Model ID")]
+        [Description("Provide the language model ID to use. (Example: deepseek-coder)")]
+        [DefaultValue("")]
+        public string CustomLanguageModel { get; set; } = "";
+
         [Category("General")]
         [DisplayName("API Endpoint")]
         [Description("URL containing the OpenAI API endpoint and request format ({0}=version, {1}=request)")]
         [DefaultValue("https://api.openai.com/{0}/{1}")]
         public string ApiEndpoint { get; set; } = "https://api.openai.com/{0}/{1}";
+
     }
 }

--- a/source.extension.vsixmanifest
+++ b/source.extension.vsixmanifest
@@ -1,23 +1,23 @@
 <?xml version="1.0" encoding="utf-8"?>
 <PackageManifest Version="2.0.0" xmlns="http://schemas.microsoft.com/developer/vsx-schema/2011" xmlns:d="http://schemas.microsoft.com/developer/vsx-schema-design/2011">
-	<Metadata>
-		<Identity Id="AI_Studio.74F4FED3-20F1-4F08-BEC5-1219C8EDC2AD" Version="1.4.0" Language="en-US" Publisher="Emrah Kondur" />
-		<DisplayName>AI Studio</DisplayName>
-		<Description xml:space="preserve">AI Studio helps you with the power of chatGPT in many subjects such as adding unit tests, refactoring code, adding summary, etc. while writing code, just by right click on the code.</Description>
-		<ReleaseNotes>Added option to set API endpoint  / URL format</ReleaseNotes>
-		<Icon>Resources\Icon.png</Icon>
-		<PreviewImage>Resources\Icon.png</PreviewImage>
-		<Tags>AI, chatGPT, UnitTest, Refactor, Summary, OpenAI</Tags>
-	</Metadata>
-	<Installation AllUsers="true">
-		<InstallationTarget Version="[17.0,18.0)" Id="Microsoft.VisualStudio.Community">
-			<ProductArchitecture>amd64</ProductArchitecture>
-		</InstallationTarget>
-	</Installation>
-	<Prerequisites>
-		<Prerequisite Id="Microsoft.VisualStudio.Component.CoreEditor" Version="[17.0,)" DisplayName="Visual Studio core editor" />
-	</Prerequisites>
-	<Assets>
-		<Asset Type="Microsoft.VisualStudio.VsPackage" d:Source="Project" d:ProjectName="%CurrentProject%" Path="|%CurrentProject%;PkgdefProjectOutputGroup|" />
-	</Assets>
+    <Metadata>
+        <Identity Id="AI_Studio.74F4FED3-20F1-4F08-BEC5-1219C8EDC2AD" Version="1.4.1" Language="en-US" Publisher="Emrah Kondur" />
+        <DisplayName>AI Studio</DisplayName>
+        <Description xml:space="preserve">AI Studio helps you with the power of chatGPT in many subjects such as adding unit tests, refactoring code, adding summary, etc. while writing code, just by right click on the code.</Description>
+        <ReleaseNotes>Added option to set API endpoint  / URL format</ReleaseNotes>
+        <Icon>Resources\Icon.png</Icon>
+        <PreviewImage>Resources\Icon.png</PreviewImage>
+        <Tags>AI, chatGPT, UnitTest, Refactor, Summary, OpenAI</Tags>
+    </Metadata>
+    <Installation AllUsers="true">
+        <InstallationTarget Version="[17.0,18.0)" Id="Microsoft.VisualStudio.Community">
+            <ProductArchitecture>amd64</ProductArchitecture>
+        </InstallationTarget>
+    </Installation>
+    <Prerequisites>
+        <Prerequisite Id="Microsoft.VisualStudio.Component.CoreEditor" Version="[17.0,)" DisplayName="Visual Studio core editor" />
+    </Prerequisites>
+    <Assets>
+        <Asset Type="Microsoft.VisualStudio.VsPackage" d:Source="Project" d:ProjectName="%CurrentProject%" Path="|%CurrentProject%;PkgdefProjectOutputGroup|" />
+    </Assets>
 </PackageManifest>


### PR DESCRIPTION
Let me know if you need some insights. Tested with my local OpenAI service running on LM Studio.

![image](https://github.com/user-attachments/assets/4c6bf8bf-9a9d-4410-b016-3dbc3c817229)
